### PR TITLE
Fix initialization in append

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn append<W: Write>(
 ) {
     for path in src {
         let path = path.unwrap();
-        let mut buf;
+        let mut buf = PathBuf::new();
         let mut target = *target.as_ref().unwrap_or(&path.as_ref());
         if target_is_dir(target) {
             buf = target.to_path_buf();


### PR DESCRIPTION
## Summary
- fix uninitialized PathBuf when appending files

## Testing
- `cargo check` *(fails: failed to fetch git dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e89aab9c48320b85ce33aa880ef3e