### PR TITLE
Fix extraction check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn get_decoder(file_type: &str, file: File) -> Box<dyn Read> {
 
 fn extract(format_type: &str, filepath: &Path, dst: &str, compression_only: bool) {
     let dst: &Path = dst.as_ref();
-    if dst.exists() & (!dst.is_dir()) {
+    if dst.exists() && !dst.is_dir() {
         panic!("dst path {} exists", dst.display());
     }
     let file = std::fs::File::open(filepath).unwrap();


### PR DESCRIPTION
## Summary
- use logical `&&` instead of bitwise `&` when verifying the extraction target path

## Testing
- `cargo check` *(fails: failed to get `xz2` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684e8d6b08e483208961b7f953362634