### PR TITLE
Update append help text

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
                         .takes_value(true)
                         .multiple(true)
                         .required(true)
-                        .help("append file to new package.allow glob and rename."),
+                        .help("append file to new package. Allow glob and rename."),
                 ),
         )
         .subcommand(


### PR DESCRIPTION
## Summary
- update wording for `append` arg help

## Testing
- `cargo check --offline` *(fails: failed to get `xz2` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684e8de92fec8320b3cde5d446cf7c51