### PR TITLE
Add "Milo's Pocket Powers" series bible and Book 1 production document

### DIFF
--- a/book1-milo-and-the-volcano-inside.md
+++ b/book1-milo-and-the-volcano-inside.md
@@ -1,0 +1,150 @@
+# BOOK 1 — "Milo and the Volcano Inside" (Complete Production Document)
+
+> Series: **Milo's Pocket Powers** · Book #1 of 12 · Theme: **Anger management** · Ages 3–7 · 32 pages
+> Mentor: **Grandpa Joe** · Pocket Power: **The Balloon Breath** · Emotion visual code: red-orange **volcano swirl** cooling to soft blue
+> This document must always be read together with the Series Bible (`milos-pocket-powers-master-prompt.md`). The Bible wins on any conflict.
+
+---
+
+## 1. BOOK SUMMARY (one paragraph)
+
+Milo builds the tallest block tower EVER — and his toddler sister Pia knocks it down with a hug. A hot
+volcano of anger rises inside Milo. Squishing it down and yelling into his pillow only make it worse.
+Grandpa Joe arrives with a Pocket Power made just for volcanoes: the Balloon Breath. It doesn't work on
+the first try — volcanoes are stubborn — but breath by breath the volcano cools into a warm little pebble.
+Milo forgives Pia, and together they build a crooked, wobbly, absolutely BEST tower ever.
+
+**Takeaways for the child:** anger is normal and has body signals; it can be cooled with a simple breathing
+technique; repairing the relationship afterward feels better than the tower ever did.
+
+## 2. THE POCKET POWER: "The Balloon Breath"
+
+- Breathe in slowly through the **nose** — "fill the balloon" (belly expands).
+- Blow out slowly through the **mouth** — "let the balloon fly" (long, slow exhale).
+- Repeat 3+ times. Based on diaphragmatic breathing used in child CBT for arousal regulation.
+- Child-facing rules: it never works on the first try in the story (realism rule); it is framed as a
+  power/tool, never as a punishment or a way to make feelings "go away".
+
+## 3. FULL MANUSCRIPT + ILLUSTRATION BRIEFS (page by page)
+
+Format notes: trim 8.5" × 8.5"; spreads are two facing pages; keep a ~25% quiet zone for text on every
+illustration; palette per Series Bible (cream `#F7F0E3`, mustard `#E8B939`, coral `#E85D4A`, navy `#2E4057`,
+calm blue `#8FB8CE`); anger swirl gradient `#E85D4A → #F49B42`.
+
+### Page 1 — Title / dedication page
+- **Text:** *Milo and the Volcano Inside* — plus dedication line (author to supply).
+- **Illustration:** Quiet vignette on cream: Milo's red sneakers by the front door next to Pia's tiny shoes. (Canonical image — Series Bible continuity log #2.)
+
+### Spread pp. 2–3 — Normal life
+- **Text:** "This is Milo. Milo loves three things: building towers, racing his toy cars, and his little sister Pia... *most* of the time."
+- **Illustration:** Milo's bedroom (canonical layout: blue-grey walls, window LEFT with warm daylight, block basket RIGHT, family photo on wall). Milo mid-build on a big tower; toy cars parked in a row; Pia toddling in at the doorway with grabby hands. Mood: sunny, playful. *"most of the time"* lands as a visual joke via Milo's sideways glance at Pia.
+
+### Spread pp. 4–5 — Pride (setup)
+- **Text:** "Today, Milo built the tallest tower EVER. Taller than the chair! Taller than the lamp! Almost as tall as Milo himself."
+- **Illustration:** Low camera angle making the tower feel huge. Milo arms raised in triumph (Style-test Scene A pose). The top block very slightly tilted — foreshadowing. Chair and lamp visible for the comparisons.
+
+### Spread pp. 6–7 — The crash (trigger)
+- **Text:** "Then... CRASH! Pia wanted to hug the tower. Towers do not like hugs."
+- **Illustration:** Action spread: blocks flying, motion lines kept soft (no comic-book harshness). Pia sitting in the rubble, delighted and oblivious. Milo frozen, eyes wide, one hand still raised. "CRASH!" may be set as display lettering integrated into the art.
+
+### Spread pp. 8–9 — The feeling rises (naming the body signal)
+- **Text:** "Something hot woke up in Milo's tummy. It bubbled. It rumbled. It rose up, up, up — like a volcano."
+- **Illustration:** First appearance of the series' **volcano swirl**: a glowing red-orange spiral in Milo's belly, rising toward his chest. Background cools/darkens slightly so the swirl reads as the hottest thing on the page. Milo's brows knitting, fists starting to curl.
+
+### Spread pp. 10–11 — Eruption (emotion peak)
+- **Text:** "\"PIAAAAA!\" Milo roared. He stomped his feet. He squeezed his fists. His face turned red as a fire truck."
+- **Illustration:** Full-bleed eruption (Style-test Scene B). Milo mid-stomp, face flushed, swirl at maximum size. Pia startled, lip wobbling. Keep Milo sympathetic, not scary: exaggerated but rounded shapes, no aggressive teeth.
+
+### Spread pp. 12–13 — Failed attempts (humor beat)
+- **Text:** "Milo tried to squish the volcano down. But squishing made it bigger. He tried yelling into his pillow. But the volcano just yelled back."
+- **Illustration:** Two comic panels: (1) Milo hugging his own belly trying to squash the swirl — it bulges out bigger above his arms; (2) Milo face-down yelling into the pillow — a muffled "blorp" of swirl puffing back out at him. This is the laugh moment; keep it light.
+
+### Spread pp. 14–15 — Low point (feel the feeling)
+- **Text:** "Pia started to cry. Mom looked tired. And Milo felt hot and prickly and all alone."
+- **Illustration:** Muted, desaturated palette (the ONLY spread allowed to break the warm palette). Milo small in the corner of the messy room; Pia crying; Maya in the doorway with the canonical "tired look" — a hand on her forehead, not angry. Lots of empty space around Milo = loneliness.
+
+### Spread pp. 16–17 — Mentor arrives
+- **Text:** "That's when Grandpa Joe peeked in. \"Whoa! A volcano!\" he said. \"Good thing I keep a Pocket Power just for volcanoes.\""
+- **Illustration:** Grandpa Joe (round glasses, bushy grey mustache, patched olive-green vest) kneeling to Milo's eye level (his canonical habit), one hand patting his vest pocket, warm wink. Warmth returns to the palette with him. Milo tear-streaked but curious.
+
+### Spread pp. 18–19 — Teaching the Pocket Power (instructional spread)
+- **Text:** "\"It's called the Balloon Breath. Breathe in through your nose — fill the balloon. Blow out through your mouth — sloooowly let it fly.\""
+- **Illustration:** The most functional spread in the book — designed to be used by parents as an exercise chart. Grandpa demonstrating; a soft, semi-transparent imaginary balloon inflating above them; simple arrows: nose-in, mouth-out. Composition must stay clear at thumbnail size.
+
+### Spread pp. 20–21 — First try fails (realism rule)
+- **Text:** "Milo tried. Sniff... whoooosh. The volcano still grumbled. \"Volcanoes are stubborn,\" said Grandpa Joe. \"Try again.\""
+- **Illustration:** Milo's cheeks puffed, eyes crossed with effort — endearing, slightly funny. Swirl barely smaller, grumbling with little cartoon rumble marks. Grandpa's encouraging nod.
+
+### Spread pp. 22–23 — It works (transformation)
+- **Text:** "Sniff... whoooooooosh. The hot feeling got smaller. Sniff... whooooooooooosh. Smaller. And smaller. Until the volcano was just a warm little pebble."
+- **Illustration:** Three-beat progression across the spread: swirl shrinking with each breath, color cooling from `#E85D4A` through orange to calm blue `#8FB8CE`, ending as a tiny pebble-sized glow. Milo's shoulders visibly dropping, brows unknitting. This color transition is series-canonical.
+
+### Spread pp. 24–25 — Repair scene (mandatory)
+- **Text:** "Milo looked at the blocks. He looked at Pia's wet cheeks. \"You didn't mean it,\" he said. \"Want to build one together?\""
+- **Illustration:** Quiet, tender: Milo crouching to Pia's level (mirroring Grandpa's habit — visual echo), offering her a block. Pia's tears turning to a wobbly smile.
+
+### Spread pp. 26–27 — Victory
+- **Text:** "They built a new tower. It was crooked. It was wobbly. It was the BEST tower ever — because they built it together."
+- **Illustration:** Warm full spread: the crooked two-builder tower (canonical object — continuity log #1), Milo and Pia proud, Maya and Ben peeking in from the doorway smiling, Grandpa Joe giving a thumbs up. Golden-hour light.
+
+### Spread pp. 28–29 — Rhyming closer + slogan
+- **Text:**
+  "When the volcano wakes and starts to blow,
+  fill your balloon and let it go.
+  Big feelings come, big feelings pass —
+  **Little tricks for BIG feelings!**"
+- **Illustration:** Milo breaking the fourth wall: winking at the reader, holding up a round **"Balloon Breath" badge** (this badge design is reused on the cover and the p. 32 collection grid).
+
+### Page 30 — For Grown-Ups
+- **Heading:** "For Grown-Ups: Taming Volcanoes Together"
+- **Talk-together questions:** 1) "Where do you feel anger in your body?" 2) "What does *your* volcano feel like — hot, bubbly, loud?" 3) "What made Milo's volcano shrink?"
+- **Three coaching tips:** 1) Practice the Balloon Breath when everyone is CALM, so it's familiar during a real storm. 2) Name the feeling first ("You're really angry — your volcano is awake"), teach second. 3) Model it: let your child see YOU use the Balloon Breath when you're frustrated.
+- **Illustration:** minimal — small spot art of the pebble.
+
+### Page 31 — Activity page
+- **Activity 1:** "Draw YOUR volcano!" — empty belly-outline of a child figure to draw the feeling inside.
+- **Activity 2:** Cut-out **Balloon Breath fridge chart**: 3 pictured steps (nose in → balloon fills → mouth out slowly).
+- **Illustration:** line-art style (colorable), consistent character model.
+
+### Page 32 — Series page
+- **Text:** "Milo has more Pocket Powers! Coming next: *Milo and the Worry Cloud* (Book 2)." + "Collect all the Pocket Powers!" badge grid (Balloon Breath badge unlocked/colored, others greyed).
+
+**Word count target:** ~430 words (verified against the 400–700 rule; heavy-rhyme cap not applicable — only the closer rhymes).
+
+## 4. COVER BRIEF
+
+- **Front:** Series cover template — Milo centered, mid-Balloon-Breath with the shrinking volcano swirl visible; the round "Balloon Breath" badge top-right under the series logo "Milo's Pocket Powers"; book number badge "1" bottom-right. Title typography: *Milo and the Volcano Inside*, warm display font, high shelf contrast (mustard + coral on cream).
+- **Back:** Slogan "Little tricks for BIG feelings!" + parent-facing hook: "Does your little one erupt like a volcano? Milo knows the feeling — and Grandpa Joe has a Pocket Power for that." + 3 bullet benefits (names the body signals of anger · teaches a real calming technique · ends with connection, not punishment) + badge strip + barcode zone.
+- **Spine:** none (32-page saddle/perfect binding at KDP does not print a usable spine at this page count).
+
+## 5. AMAZON KDP METADATA (draft)
+
+- **Title:** Milo and the Volcano Inside
+- **Subtitle:** An Anger Management Book for Kids Ages 3–7 (Milo's Pocket Powers, Book 1)
+- **Series name:** Milo's Pocket Powers
+- **Description (draft):** "CRASH! When Pia knocks down Milo's tallest tower EVER, something hot wakes up in his tummy... Join Milo as Grandpa Joe teaches him the Balloon Breath — a simple, real technique your child can use the very next time their own volcano wakes up. With a feelings guide for grown-ups and an activity page inside. *Little tricks for BIG feelings!*"
+- **Keywords (7 slots, draft):** anger management books for kids · emotions book for toddlers · calm down book for kids · social emotional learning preschool · feelings book ages 3-5 · books about anger for children · breathing exercises for kids
+- **Categories (pick 2–3):** Juvenile Fiction > Social Themes > Emotions & Feelings · Juvenile Nonfiction > Social Topics > Manners & Etiquette (alt) · Juvenile Fiction > Family > Multigenerational
+- **Trim/print:** 8.5" × 8.5", premium color recommended, white paper, paperback; ebook via Kindle Kids' Book Creator or fixed-layout EPUB.
+
+## 6. PRODUCTION CHECKLIST (Book 1)
+
+- [ ] Read-aloud rhythm pass (adult reads to a 3–5 y/o; note stumbles)
+- [ ] Test-read with 2–3 children ages 3–7; watch: do they laugh at pp. 12–13? do they try the breath at pp. 18–19?
+- [ ] Pedagogue/preschool-teacher review of pp. 18–19 and p. 30 wording
+- [ ] Style test completed and Style Guide locked (Scenes A/B/C per illustration brief)
+- [ ] 15 illustrations commissioned (1 title vignette + 13 spreads + p.30 spot art) + p.31 line art + cover
+- [ ] Layout with bleed 0.125", quiet-zone check on every spread, thumbnail legibility check on pp. 18–19
+- [ ] Proofread (US English), KDP metadata finalized, categories confirmed
+- [ ] Update Series Bible continuity log after final art (any new canonical props)
+- [ ] Launch plan: hold release until Books 1–3 are ready (series launch strategy)
+
+## 7. CANONICAL FACTS ESTABLISHED BY THIS BOOK (feeds the Series Bible)
+
+1. The volcano swirl = anger; cools red→blue when calming.
+2. The Balloon Breath = Pocket Power #1; badge design reused across the series.
+3. Milo & Pia's crooked tower exists (callback material for later books).
+4. Red sneakers by the front door next to Pia's tiny shoes (title-page vignette).
+5. Grandpa Joe kneels to child eye level; Pocket Powers "come from" his vest pockets.
+6. Maya's "tired look" (hand on forehead, never angry) = the imperfect-parent visual.
+7. Milo's verbal tic "EVER!" used twice (pp. 4–5, 26–27) — keep this frequency in future books.

--- a/build_epub.py
+++ b/build_epub.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Build the EPUB 3 package for 'Milo and the Volcano Inside' (Milo's Pocket Powers, Book 1)."""
+import os
+import shutil
+import zipfile
+
+ASSETS = "/opt/cursor/artifacts/assets"
+OUT = "/workspace/milo-and-the-volcano-inside.epub"
+
+XHTML_HEAD = """<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en" xml:lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>{title}</title>
+  <link rel="stylesheet" type="text/css" href="../css/style.css"/>
+</head>
+<body>
+"""
+XHTML_FOOT = "</body>\n</html>\n"
+
+CSS = """
+body { margin: 0; padding: 0; background: #F7F0E3; font-family: "Georgia", "Times New Roman", serif; color: #2E4057; }
+.page { text-align: center; padding: 1em; }
+.page img { max-width: 100%; height: auto; border-radius: 6px; }
+.story { font-size: 1.25em; line-height: 1.6; margin: 0.8em auto 0 auto; max-width: 30em; text-align: center; }
+.story .shout { font-weight: bold; letter-spacing: 0.05em; }
+h1, h2 { font-family: "Georgia", serif; color: #E85D4A; text-align: center; }
+h1 { font-size: 1.9em; margin: 0.6em 0 0.2em 0; }
+h2 { font-size: 1.4em; }
+.subtitle { text-align: center; color: #2E4057; font-style: italic; margin-top: 0; }
+.rhyme { font-size: 1.3em; line-height: 1.8; font-style: italic; text-align: center; margin-top: 0.8em; }
+.slogan { font-weight: bold; font-style: normal; color: #E85D4A; }
+.backmatter { max-width: 32em; margin: 0 auto; padding: 1.5em; font-size: 1.05em; line-height: 1.6; }
+.backmatter li { margin-bottom: 0.6em; }
+.badge-note { text-align: center; font-style: italic; color: #8a7f6a; }
+.copyright { font-size: 0.85em; color: #8a7f6a; text-align: center; margin-top: 2em; }
+"""
+
+def img_page(fname, title, img, paragraphs, cls="story"):
+    body = f'<div class="page"><img src="../images/{img}" alt="{title}"/>\n'
+    for p in paragraphs:
+        body += f'<p class="{cls}">{p}</p>\n'
+    body += "</div>\n"
+    return fname, XHTML_HEAD.format(title=title) + body + XHTML_FOOT
+
+pages = []
+
+# Cover
+pages.append(("cover.xhtml", XHTML_HEAD.format(title="Cover")
+    + '<div class="page"><img src="../images/book1-cover.png" alt="Milo and the Volcano Inside — cover"/></div>\n'
+    + XHTML_FOOT))
+
+# Title page
+pages.append(("title.xhtml", XHTML_HEAD.format(title="Title Page")
+    + '<div class="page">'
+    + '<h1>Milo and the Volcano Inside</h1>'
+    + '<p class="subtitle">Milo&#8217;s Pocket Powers &#8226; Book 1</p>'
+    + '<p class="subtitle">Little tricks for BIG feelings!</p>'
+    + '<img src="../images/book1-p01-title.png" alt="Milo&#8217;s red sneakers next to Pia&#8217;s tiny shoes by the front door"/>'
+    + '<p class="copyright">Text and illustrations &#169; 2026. All rights reserved.</p>'
+    + '</div>\n' + XHTML_FOOT))
+
+story = [
+    ("p02.xhtml", "Milo", "book1-p02-03-intro.png",
+     ["This is Milo. Milo loves three things: building towers, racing his toy cars, and his little sister Pia&#8230; <em>most</em> of the time."]),
+    ("p04.xhtml", "The Tallest Tower", "book1-p04-05-pride.png",
+     ["Today, Milo built the tallest tower EVER. Taller than the chair! Taller than the lamp! Almost as tall as Milo himself."]),
+    ("p06.xhtml", "Crash", "book1-p06-07-crash.png",
+     ["Then&#8230; <span class=\"shout\">CRASH!</span> Pia wanted to hug the tower. Towers do not like hugs."]),
+    ("p08.xhtml", "Something Hot", "book1-p08-09-rising.png",
+     ["Something hot woke up in Milo&#8217;s tummy. It bubbled. It rumbled. It rose up, up, up &#8212; like a volcano."]),
+    ("p10.xhtml", "The Eruption", "book1-p10-11-eruption.png",
+     ["<span class=\"shout\">&#8220;PIAAAAA!&#8221;</span> Milo roared. He stomped his feet. He squeezed his fists. His face turned red as a fire truck."]),
+    ("p12.xhtml", "Stubborn Volcano", "book1-p12-13-failed.png",
+     ["Milo tried to squish the volcano down. But squishing made it bigger.",
+      "He tried yelling into his pillow. But the volcano just yelled back."]),
+    ("p14.xhtml", "All Alone", "book1-p14-15-lowpoint.png",
+     ["Pia started to cry. Mom looked tired. And Milo felt hot and prickly and all alone."]),
+    ("p16.xhtml", "Grandpa Joe", "book1-p16-17-grandpa.png",
+     ["That&#8217;s when Grandpa Joe peeked in. &#8220;Whoa! A volcano!&#8221; he said. &#8220;Good thing I keep a Pocket Power just for volcanoes.&#8221;"]),
+    ("p18.xhtml", "The Balloon Breath", "book1-p18-19-teaching.png",
+     ["&#8220;It&#8217;s called the Balloon Breath. Breathe in through your nose &#8212; fill the balloon. Blow out through your mouth &#8212; sloooowly let it fly.&#8221;"]),
+    ("p20.xhtml", "Try Again", "book1-p20-21-firsttry.png",
+     ["Milo tried. Sniff&#8230; whoooosh. The volcano still grumbled.",
+      "&#8220;Volcanoes are stubborn,&#8221; said Grandpa Joe. &#8220;Try again.&#8221;"]),
+    ("p22.xhtml", "Smaller and Smaller", "book1-p22-23-itworks.png",
+     ["Sniff&#8230; whoooooooosh. The hot feeling got smaller.",
+      "Sniff&#8230; whooooooooooosh. Smaller. And smaller. Until the volcano was just a warm little pebble."]),
+    ("p24.xhtml", "Together", "book1-p24-25-repair.png",
+     ["Milo looked at the blocks. He looked at Pia&#8217;s wet cheeks.",
+      "&#8220;You didn&#8217;t mean it,&#8221; he said. &#8220;Want to build one together?&#8221;"]),
+    ("p26.xhtml", "The Best Tower Ever", "book1-p26-27-victory.png",
+     ["They built a new tower. It was crooked. It was wobbly. It was the BEST tower ever &#8212; because they built it together."]),
+]
+for f, t, i, ps in story:
+    pages.append(img_page(f, t, i, ps))
+
+# Rhyming closer
+pages.append(("p28.xhtml", XHTML_HEAD.format(title="Little Tricks for Big Feelings")
+    + '<div class="page"><img src="../images/book1-p28-29-closer.png" alt="Milo winks at the reader holding the Balloon Breath badge"/>'
+    + '<p class="rhyme">When the volcano wakes and starts to blow,<br/>'
+    + 'fill your balloon and let it go.<br/>'
+    + 'Big feelings come, big feelings pass &#8212;<br/>'
+    + '<span class="slogan">Little tricks for BIG feelings!</span></p></div>\n'
+    + XHTML_FOOT))
+
+# For Grown-Ups
+pages.append(("p30.xhtml", XHTML_HEAD.format(title="For Grown-Ups")
+    + '<div class="backmatter"><h2>For Grown-Ups: Taming Volcanoes Together</h2>'
+    + '<p><strong>Talk together:</strong></p><ul>'
+    + '<li>&#8220;Where do you feel anger in your body?&#8221;</li>'
+    + '<li>&#8220;What does <em>your</em> volcano feel like &#8212; hot, bubbly, loud?&#8221;</li>'
+    + '<li>&#8220;What made Milo&#8217;s volcano shrink?&#8221;</li></ul>'
+    + '<p><strong>Three tips for coaching the Balloon Breath:</strong></p><ol>'
+    + '<li>Practice when everyone is <em>calm</em>, so the Balloon Breath feels familiar during a real storm.</li>'
+    + '<li>Name the feeling first (&#8220;You&#8217;re really angry &#8212; your volcano is awake&#8221;), teach second.</li>'
+    + '<li>Model it: let your child see <em>you</em> use the Balloon Breath when you&#8217;re frustrated.</li></ol>'
+    + '</div>\n' + XHTML_FOOT))
+
+# Activity page
+pages.append(("p31.xhtml", XHTML_HEAD.format(title="Activity Page")
+    + '<div class="backmatter"><h2>Your Turn!</h2>'
+    + '<p><strong>1. Draw YOUR volcano!</strong> What color is it? Is it big or small? Where does it live in your body? Grab paper and crayons and draw it.</p>'
+    + '<p><strong>2. The Balloon Breath, step by step:</strong></p><ol>'
+    + '<li>Breathe in slowly through your <strong>nose</strong> &#8212; fill the balloon.</li>'
+    + '<li>Feel your tummy grow round like a balloon.</li>'
+    + '<li>Blow out sloooowly through your <strong>mouth</strong> &#8212; let the balloon fly!</li>'
+    + '<li>Do it three times. Is your volcano smaller?</li></ol>'
+    + '</div>\n' + XHTML_FOOT))
+
+# Series page
+pages.append(("p32.xhtml", XHTML_HEAD.format(title="More Pocket Powers")
+    + '<div class="backmatter"><h2>Milo has more Pocket Powers!</h2>'
+    + '<p class="badge-note">You unlocked: <strong>The Balloon Breath</strong> &#127880;</p>'
+    + '<p>Coming next: <em>Milo and the Worry Cloud</em> (Book 2), where Nana Rose shares a Pocket Power for worries.</p>'
+    + '<p class="badge-note">Collect all the Pocket Powers!</p>'
+    + '<p class="rhyme"><span class="slogan">Little tricks for BIG feelings!</span></p>'
+    + '</div>\n' + XHTML_FOOT))
+
+images = [
+    "book1-cover.png", "book1-p01-title.png", "book1-p02-03-intro.png",
+    "book1-p04-05-pride.png", "book1-p06-07-crash.png", "book1-p08-09-rising.png",
+    "book1-p10-11-eruption.png", "book1-p12-13-failed.png", "book1-p14-15-lowpoint.png",
+    "book1-p16-17-grandpa.png", "book1-p18-19-teaching.png", "book1-p20-21-firsttry.png",
+    "book1-p22-23-itworks.png", "book1-p24-25-repair.png", "book1-p26-27-victory.png",
+    "book1-p28-29-closer.png",
+]
+
+manifest_items, spine_items = [], []
+for f, _ in pages:
+    pid = f.replace(".xhtml", "")
+    props = ' properties="svg"' if False else ""
+    manifest_items.append(f'<item id="{pid}" href="xhtml/{f}" media-type="application/xhtml+xml"{props}/>')
+    spine_items.append(f'<itemref idref="{pid}"/>')
+for img in images:
+    iid = img.replace(".png", "").replace("-", "_")
+    cover_prop = ' properties="cover-image"' if img == "book1-cover.png" else ""
+    manifest_items.append(f'<item id="{iid}" href="images/{img}" media-type="image/png"{cover_prop}/>')
+
+OPF = f"""<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="bookid" xml:lang="en">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="bookid">urn:uuid:7f2c9a44-b1e6-4f7d-9c3a-4d8e21f6b0a5</dc:identifier>
+    <dc:title>Milo and the Volcano Inside</dc:title>
+    <dc:creator>Milo's Pocket Powers</dc:creator>
+    <dc:language>en</dc:language>
+    <dc:description>When Pia knocks down Milo's tallest tower EVER, something hot wakes up in his tummy. Grandpa Joe teaches him the Balloon Breath — a real calming technique for kids ages 3-7. Book 1 of the Milo's Pocket Powers series. Little tricks for BIG feelings!</dc:description>
+    <dc:subject>Anger management for children</dc:subject>
+    <meta property="dcterms:modified">2026-08-03T16:00:00Z</meta>
+    <meta property="belongs-to-collection" id="series">Milo's Pocket Powers</meta>
+    <meta refines="#series" property="collection-type">series</meta>
+    <meta refines="#series" property="group-position">1</meta>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="css" href="css/style.css" media-type="text/css"/>
+    {chr(10).join('    ' + m for m in manifest_items)}
+  </manifest>
+  <spine>
+    {chr(10).join('    ' + s for s in spine_items)}
+  </spine>
+</package>
+"""
+
+NAV = XHTML_HEAD.format(title="Contents").replace('href="../css/', 'href="css/') + """
+<nav epub:type="toc" id="toc">
+  <h1>Contents</h1>
+  <ol>
+    <li><a href="xhtml/cover.xhtml">Cover</a></li>
+    <li><a href="xhtml/title.xhtml">Title Page</a></li>
+    <li><a href="xhtml/p02.xhtml">The Story</a></li>
+    <li><a href="xhtml/p28.xhtml">Little Tricks for BIG Feelings</a></li>
+    <li><a href="xhtml/p30.xhtml">For Grown-Ups</a></li>
+    <li><a href="xhtml/p31.xhtml">Activity Page</a></li>
+    <li><a href="xhtml/p32.xhtml">More Pocket Powers</a></li>
+  </ol>
+</nav>
+""" + XHTML_FOOT
+
+CONTAINER = """<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+
+build = "/tmp/epub-build"
+shutil.rmtree(build, ignore_errors=True)
+os.makedirs(f"{build}/META-INF")
+os.makedirs(f"{build}/OEBPS/xhtml")
+os.makedirs(f"{build}/OEBPS/images")
+os.makedirs(f"{build}/OEBPS/css")
+
+open(f"{build}/mimetype", "w").write("application/epub+zip")
+open(f"{build}/META-INF/container.xml", "w").write(CONTAINER)
+open(f"{build}/OEBPS/content.opf", "w").write(OPF)
+open(f"{build}/OEBPS/nav.xhtml", "w").write(NAV)
+open(f"{build}/OEBPS/css/style.css", "w").write(CSS)
+for f, content in pages:
+    open(f"{build}/OEBPS/xhtml/{f}", "w").write(content)
+for img in images:
+    shutil.copy(os.path.join(ASSETS, img), f"{build}/OEBPS/images/{img}")
+
+if os.path.exists(OUT):
+    os.remove(OUT)
+with zipfile.ZipFile(OUT, "w") as z:
+    z.write(f"{build}/mimetype", "mimetype", compress_type=zipfile.ZIP_STORED)
+    for root, _, files in os.walk(build):
+        for f in sorted(files):
+            full = os.path.join(root, f)
+            rel = os.path.relpath(full, build)
+            if rel == "mimetype":
+                continue
+            z.write(full, rel, compress_type=zipfile.ZIP_DEFLATED)
+
+print(f"Built {OUT} ({os.path.getsize(OUT) / 1024 / 1024:.1f} MB)")

--- a/milos-pocket-powers-master-prompt.md
+++ b/milos-pocket-powers-master-prompt.md
@@ -1,0 +1,141 @@
+# MASTER PROJECT CONTEXT — "Milo's Pocket Powers" Children's Book Series
+
+> **HOW TO USE THIS DOCUMENT (instruction to the AI assistant reading this):**
+> You are the writing and production assistant for the children's picture book series described below.
+> This document is the **Series Bible v1.1** — the single source of truth. Everything you write or design
+> for this series MUST be consistent with it. If a new character, location, object, or rule is needed,
+> you must first propose it as an addition to this Bible, and only use it after the author approves.
+> The author communicates in Turkish; respond in Turkish, but write ALL book content in English.
+
+---
+
+## 1. SERIES OVERVIEW
+
+- **Series name:** Milo's Pocket Powers
+- **Slogan (appears in every book):** "Little tricks for BIG feelings!"
+- **Audience:** Children ages 3–7, global English-language market (Amazon KDP first)
+- **Format:** 32 pages, square 8.5" × 8.5" (2625 × 2625 px at 300 DPI incl. bleed), 400–700 words per book
+- **Core mechanic:** In every book, Milo faces one emotional/social challenge. His grandparents teach him
+  one named, concrete coping technique called a **"Pocket Power"** (always a 2-word name in the format
+  "The ___ ___", e.g. *The Balloon Breath*, *The Worry Jar*).
+- **Positioning:** A deliberate blend of two proven models, plus original differentiation:
+  - From Elizabeth Cole's style: emotional depth, feelings are validated and fully felt before being solved,
+    parent guide + activity pages at the back.
+  - From Ninja Life Hacks: pace, humor, one concrete named technique per book, strict series template,
+    collectibility (numbered books, badges).
+  - **Original to us:** a persistent, living world (real family, same house, continuity between books);
+    imperfect but loving adults; cross-book "easter egg" callbacks; dual mentor structure (see below).
+
+## 2. CHARACTER BIBLE (canonical — never contradict)
+
+| Character | Age | Role | Canonical details |
+|---|---|---|---|
+| **Milo** | 5 (never ages) | Protagonist | Messy medium-brown hair with a cowlick at the back (silhouette signature), large warm brown eyes, thick expressive eyebrows, light-medium warm skin. Standard outfit: mustard-yellow t-shirt, navy shorts, red sneakers with white laces. Loves building towers and toy cars. Verbal tic: exaggerates with "EVER!" ("tallest tower EVER!"). Feels everything BIG — that's his challenge and his charm. |
+| **Pia** | 2 | Little sister | Two tiny hair buns. Creates chaos out of love; is NEVER portrayed as "bad" or blamed. |
+| **Maya** | adult | Mom | Architect. Warm but sometimes visibly tired (imperfect-parent principle). |
+| **Ben** | adult | Dad | Cook. Funny but forgetful. Adults may make mistakes and apologize — this models behavior. |
+| **Nana Rose** | grandmother | Mentor #1 | The sage of *naming feelings* (the emotional/Cole side). Leads books about inward feelings (worry, sadness, jealousy). |
+| **Grandpa Joe** | 68, grandfather | Mentor #2 | The master of *techniques and games* (the practical/Nhin side). Round glasses, bushy grey mustache, patched olive-green vest with deep pockets (signature — Pocket Powers "come from" his pockets). Habit: kneels to child eye level. Leads books about action skills (anger, patience, focus). |
+| **Sam** | 5 | Best friend | Milo's opposite: quiet, cautious. Introduced in Book 3. Source of conflict-and-empathy stories. |
+
+## 3. WORLD BIBLE (canonical)
+
+- **Milo's bedroom:** blue-grey walls, window on the LEFT with warm daylight, block basket on the RIGHT,
+  family photo on the wall. Same layout in every book.
+- **Emotion visual codes (series-canonical):**
+  - Anger = red-orange **"volcano swirl"** glowing in the belly/chest (`#E85D4A → #F49B42`); calming = the swirl shrinks and cools to soft blue (`#8FB8CE`).
+  - Worry = a small grey cloud that follows the character (introduced in Book 2).
+  - Each new emotion gets one simple visual signature, added to this Bible before use.
+- **Continuity log:**
+  1. Book 1: Milo and Pia built a crooked tower together at the end → may appear as a callback in later books.
+  2. Red sneakers by the front door next to Pia's tiny shoes = Book 1 title-page image (canonical).
+
+## 4. STORY RULES (mandatory for every book)
+
+**32-page template:**
+
+| Pages | Content |
+|---|---|
+| 1 | Title/dedication page |
+| 2–3 | Character intro in normal life |
+| 4–7 | The problem appears (the feeling is triggered) |
+| 8–13 | Problem grows; 2–3 comic FAILED attempts to cope (humor beat) |
+| 14–15 | Emotional low point — the feeling is fully felt, muted colors |
+| 16–19 | A mentor teaches the Pocket Power (pp. 18–19 = clear instructional spread, reusable as a parent-child exercise) |
+| 20–25 | Practice: the technique does NOT work on the first try (realism rule), works on repeat; then a **repair scene** (relationship is mended — mandatory) |
+| 26–27 | Victory moment, warm full spread |
+| 28–29 | Rhyming closer (4 lines) ending with the slogan "Little tricks for BIG feelings!" |
+| 30 | "For Grown-Ups": talk-together questions + 3 coaching tips |
+| 31 | Activity page (drawing prompt + technique picture guide) |
+| 32 | Series page: next book teaser + collect-them-all badge grid |
+
+**Language rules:** 1–4 sentences per page; prose narration with rhyme reserved for the closer and key
+technique moments; total 400–700 words (max ~500 if heavily rhymed). FORBIDDEN: labels like "bad boy",
+"naughty"; feelings are never called "wrong"; the technique never works instantly.
+
+## 5. VISUAL STYLE GUIDE (direction: "Semi-Textured Digital")
+
+- Flat, clean shape language + subtle grain/paper texture on fills + soft single-direction warm lighting.
+- Rounded chunky forms, no hard outlines, no emoji faces, no pastel-airbrush-sparkle look, no 3D/anime.
+- Emotions carried by **posture and eyebrows**. Backgrounds restrained (Scandinavian simplicity).
+- Head-to-body ratio for children ≈ 1 : 2.5.
+- Default background: warm cream, not pure white.
+- **Palette (working values):** cream `#F7F0E3`, mustard `#E8B939` (Milo), coral red `#E85D4A` (accent),
+  soft navy `#2E4057` (contrast). Max 5–6 colors per scene + the book's emotion-code color.
+- **Cover template:** Milo centered + that book's Pocket Power badge + series logo top + book number badge bottom-right.
+- Leave a ~25% "quiet zone" per illustration for text placement.
+
+## 6. BOOK 1 (COMPLETE PILOT SCRIPT) — "Milo and the Volcano Inside"
+
+**Theme:** anger. **Mentor:** Grandpa Joe. **Pocket Power:** The Balloon Breath (breathe in through the nose
+to "fill the balloon", blow out slowly through the mouth to "let it fly"). ~430 words.
+
+- **p1:** *Illo: Milo's red sneakers next to Pia's tiny shoes by the front door.*
+- **pp2–3:** "This is Milo. Milo loves three things: building towers, racing his toy cars, and his little sister Pia... *most* of the time." *Illo: Milo mid-build; Pia toddles in the doorway.*
+- **pp4–5:** "Today, Milo built the tallest tower EVER. Taller than the chair! Taller than the lamp! Almost as tall as Milo himself." *Illo: proud Milo; tower wobbling.*
+- **pp6–7:** "Then... CRASH! Pia wanted to hug the tower. Towers do not like hugs." *Illo: blocks flying, Pia delighted in the rubble, Milo frozen.*
+- **pp8–9:** "Something hot woke up in Milo's tummy. It bubbled. It rumbled. It rose up, up, up — like a volcano." *Illo: red-orange volcano swirl rising in his belly.*
+- **pp10–11:** "\"PIAAAAA!\" Milo roared. He stomped his feet. He squeezed his fists. His face turned red as a fire truck." *Illo: full-spread eruption.*
+- **pp12–13:** "Milo tried to squish the volcano down. But squishing made it bigger. He tried yelling into his pillow. But the volcano just yelled back." *Illo: two comic failed-attempt panels.*
+- **pp14–15:** "Pia started to cry. Mom looked tired. And Milo felt hot and prickly and all alone." *Illo: low point, muted colors, Milo small in the messy room.*
+- **pp16–17:** "That's when Grandpa Joe peeked in. \"Whoa! A volcano!\" he said. \"Good thing I keep a Pocket Power just for volcanoes.\"" *Illo: Grandpa kneeling to eye level, patting his pocket, winking.*
+- **pp18–19:** "\"It's called the Balloon Breath. Breathe in through your nose — fill the balloon. Blow out through your mouth — sloooowly let it fly.\"" *Illo: instructional spread, imaginary balloon above them.*
+- **pp20–21:** "Milo tried. Sniff... whoooosh. The volcano still grumbled. \"Volcanoes are stubborn,\" said Grandpa Joe. \"Try again.\"" *Illo: first attempt fails (realism rule).*
+- **pp22–23:** "Sniff... whoooooooosh. The hot feeling got smaller. Sniff... whooooooooooosh. Smaller. And smaller. Until the volcano was just a warm little pebble." *Illo: swirl shrinking, red cooling to blue.*
+- **pp24–25:** "Milo looked at the blocks. He looked at Pia's wet cheeks. \"You didn't mean it,\" he said. \"Want to build one together?\"" *Illo: repair scene — Milo hands Pia a block.*
+- **pp26–27:** "They built a new tower. It was crooked. It was wobbly. It was the BEST tower ever — because they built it together." *Illo: warm full spread, family peeking in, Grandpa's thumbs up.*
+- **pp28–29 (rhyming closer):**
+  "When the volcano wakes and starts to blow, / fill your balloon and let it go. / Big feelings come, big feelings pass — / **Little tricks for BIG feelings!**" *Illo: Milo winks at the reader holding a "Balloon Breath" badge.*
+- **p30:** For Grown-Ups — questions: "Where do you feel anger in your body?", "What does your volcano feel like?" + 3 tips for coaching the Balloon Breath during real tantrums.
+- **p31:** Activity — "Draw your volcano!" + cut-out Balloon Breath step guide for the fridge.
+- **p32:** Series page — "Coming next: *Milo and the Worry Cloud* (Book 2)" + badge grid.
+
+## 7. SERIES ROADMAP (12 books, 3 sets)
+
+**Set 1 — Emotions:** 1. Anger — *Milo and the Volcano Inside* (The Balloon Breath, Grandpa Joe) ✅ scripted ·
+2. Worry — *Milo and the Worry Cloud* (The Worry Jar, Nana Rose) · 3. Sadness (Nana Rose; Sam introduced) ·
+4. Jealousy (Nana Rose)
+
+**Set 2 — Skills:** 5. Patience (Grandpa Joe) · 6. Focus (Grandpa Joe) · 7. Perseverance / the power of "yet"
+(Grandpa Joe) · 8. Making mistakes (both mentors)
+
+**Set 3 — Values:** 9. Sharing · 10. Honesty · 11. Empathy/Kindness (e.g. "The Heart Glasses") · 12. Responsibility
+
+Each Pocket Power name must be finalized and added to this Bible before its book is scripted.
+Cross-book callback rule: each new book includes ONE subtle visual reference to an earlier book.
+
+## 8. PRODUCTION WORKFLOW (per book)
+
+1. Pick the theme from the roadmap; research the age-appropriate technique (CBT-based calming, growth mindset, etc.)
+2. Write the beat sheet → full 32-page script following Section 4, using ONLY Bible-approved characters/world
+3. Read-aloud test for rhythm; test-read with 2–3 children in the target age range
+4. Illustration briefs per spread (~15–17 illustrations) following Section 5
+5. Layout (8.5" square, 300 DPI + 0.125" bleed), proofread, pedagogue review if possible
+6. Publish via Amazon KDP (print + ebook); launch strategy: release Books 1–3 together
+7. Update the Continuity Log (Section 3) with any new canonical detail
+
+## 9. WHAT TO ASK THE AUTHOR BEFORE DEVIATING
+
+- Any new character, location, or recurring object → propose Bible addition first
+- Any change to Milo's outfit, room layout, palette, or slogan → requires explicit approval (Bible version bump)
+- Final HEX palette and Milo turnaround drawings are pending the illustration style test — treat current values as v1.x working values


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the complete planning, production, and deliverable files for the "Milo's Pocket Powers" children's picture book series (ages 3–7, 32-page books):

### `milos-pocket-powers-master-prompt.md`
The Series Bible / master context document, designed to be pasted into ChatGPT (or any AI assistant) as the project's single source of truth: series overview, character and world bibles, mandatory 32-page story template, visual style guide, pilot script, 12-book roadmap, and production workflow.

### `book1-milo-and-the-volcano-inside.md`
Complete production document for Book 1 (*Milo and the Volcano Inside*, anger management): full manuscript with per-spread illustration briefs, cover brief, Amazon KDP metadata draft, production checklist, and canonical facts feeding back into the Series Bible.

### `milo-and-the-volcano-inside.epub` + `build_epub.py`
A ready-to-read EPUB 3 of Book 1 with 16 AI-generated illustrations in the series' "semi-textured digital" style (cover, title vignette, 13 story spreads, closing page), full story text, the rhyming closer, "For Grown-Ups" guide, activity page, and series page. Validated with epubcheck (no errors, no warnings). The Python build script regenerates the EPUB from the illustration assets.

[Book 1 cover](https://cursor.com/agents/bc-c282bc58-7222-473f-9c06-6496922937ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassets%2Fbook1-cover.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c282bc58-7222-473f-9c06-6496922937ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c282bc58-7222-473f-9c06-6496922937ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

